### PR TITLE
[SYM-3135] Add permissions to support  SDK method

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,10 @@ resource "aws_iam_policy" "iam" {
         },
         {
             "Action": [
-                "iam:GetUser"
+                "iam:GetUser",
+                "iam:GetGroup",
+                "iam:ListGroupsForUser",
+                "iam:ListGroups"
             ],
             "Effect": "Allow",
             "Resource": [


### PR DESCRIPTION
# Summary
- The new `aws_iam.is_user_in_group` method requires read permissions to check an IAM User's group membership
